### PR TITLE
version.properties added

### DIFF
--- a/makeHAB
+++ b/makeHAB
@@ -22,7 +22,7 @@ HAB="/opt/openHAB"
 # The location of SmartHome Designer
 SMD="/opt/ohdesign"
 # the list of files in userdata/etc to remove
-DELFILES="config.properties custom.properties distribution.info jre.properties keys.properties org.apache.karaf.features.cfg org.apache.karaf.features.repos.cfg org.apache.karaf.management.cfg org.ops4j.pax.web.cfg profile.cfg startup.properties system.properties branding.properties branding-ssh.properties"
+DELFILES="config.properties custom.properties distribution.info jre.properties keys.properties org.apache.karaf.features.cfg org.apache.karaf.features.repos.cfg org.apache.karaf.management.cfg org.ops4j.pax.web.cfg profile.cfg startup.properties system.properties branding.properties branding-ssh.properties version.properties"
 
 mkdir -p $DOWN || (echo "cannot make dir $DOWN";exit 1)
 mkdir -p $HAB  || (echo "cannot make dir $HAB ";exit 1)


### PR DESCRIPTION
version.properties needs to be deleted too. In newer builds (since about 930) it is used to display the version number on the start page.